### PR TITLE
A tweak to support firefox webextensions

### DIFF
--- a/content.js
+++ b/content.js
@@ -73,7 +73,7 @@ var get_parent = function(curNode, parentType){
 
 switch(PLATFORM){
   case 'chrome':
-    chrome.extension.onRequest.addListener(
+    chrome.runtime.onMessage.addListener(
       function(request, sender, sendResponse){
         relay_message(request);
         sendResponse({}); // close the connection


### PR DESCRIPTION
This should be backward compatible with chrome, as it also supports onMessage.

This supports https://github.com/reading-am/reading-extensions/pull/1